### PR TITLE
Update readme with fancy badges

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -14,4 +14,4 @@ jobs:
       with:
         java-version: 1.8
     - name: Build with Gradle
-      run: ./gradlew build —-no-daemon
+      run: ./gradlew build --no-daemon

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,17 @@
+name: Java CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Build with Gradle
+      run: ./gradlew build —-no-daemon

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 A mod for 1.12.2+ by [Cadiboo](https://github.com/Cadiboo) that creates smooth terrain in Minecraft.  
 [Website](https://Cadiboo.github.io/projects/nocubes/)  
 [CurseForge Page](https://minecraft.curseforge.com/projects/nocubes)  
+![NoCubes](https://cadiboo.github.io/projects/nocubes/sd-images/realistic.png "NoCubes")
 
 ## Development
 You'll need to move the OptiFine library above Forge in your IDE's dependencies to get the mod to compile

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # [NoCubes Mod](https://Cadiboo.github.io/projects/nocubes/)
+
+[![Curseforge Downloads](http://cf.way2muchnoise.eu/full_nocubes_downloads.svg)
+![Curseforge Versions](http://cf.way2muchnoise.eu/versions/nocubes.svg)](https://www.curseforge.com/minecraft/mc-mods/nocubes)
+
 A mod for 1.12.2+ by [Cadiboo](https://github.com/Cadiboo) that creates smooth terrain in Minecraft.  
 [Website](https://Cadiboo.github.io/projects/nocubes/)  
 [CurseForge Page](https://minecraft.curseforge.com/projects/nocubes)  


### PR DESCRIPTION
Preview:

[![Curseforge Downloads](http://cf.way2muchnoise.eu/full_nocubes_downloads.svg) ![Curseforge Versions](http://cf.way2muchnoise.eu/versions/nocubes.svg)](https://www.curseforge.com/minecraft/mc-mods/nocubes)

I think a discord badge could also be added. It looks like this:

[![Discord](https://img.shields.io/discord/297104769649213441?label=Discord)
](https://discordapp.com/invite/QXbWS36)

This is the code:
```
[![Discord](https://img.shields.io/discord/297104769649213441?label=Discord)](https://discordapp.com/invite/zKP8EgY)
```
The number has to be replaced with the server id, but only the server owner has access to that.
[Here is a guide on how to retrieve it.](https://github.com/Chikachi/DiscordIntegration/wiki/How-to-get-a-token-and-channel-ID-for-Discord#get-the-channel-id-of-the-discord-text-channel)

Inspiration: [The Useful-Backpacks github.](https://github.com/MC-U-Team/Useful-Backpacks)